### PR TITLE
fix JSDoc typings for renderSVG

### DIFF
--- a/src/svg.ts
+++ b/src/svg.ts
@@ -2,7 +2,7 @@ import { encode } from './encode'
 import type { QrCodeGenerateData, QrCodeGenerateSvgOptions } from './types'
 
 /**
- * Render QR Code with ANSI color for terminal
+ * Render QR Code as SVG string
  */
 export function renderSVG(
   data: QrCodeGenerateData,


### PR DESCRIPTION
### 🔗 Linked issue
#3 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Updated the JSDoc for [`renderSVG`](https://github.com/unjs/uqr/blob/62432aa7fbd30ae846a210886d7f2d68a4dae445/src/svg.ts#L5)
Resolves #3 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
