### PR TITLE
docs: change SvgOptions pixelSize default to 10

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export interface QrCodeGenerateSvgOptions extends QrCodeGenerateOptions {
   /**
    * Size of each pixel
    *
-   * @default 20
+   * @default 10
    */
   pixelSize?: number
 


### PR DESCRIPTION
**Reference:** #

I haven't created a separate issue for this change to prevent spam. If required, I'll create one afterward. 

---

The `@default` of the `QrCodeGenerateSvgOptions`.`pixelSize` is set to `20` where the actual `svg.ts` defaults to `10`. 

I updated the docs to represent what really happens in the code, since changing the code would probably be a breaking change. 

<!--
IMPORTANT IMPORTANT IMPORTANT IMPORTANT

- Discuss the issue/idea with the maintainers using an issue BEFORE.
- Please keep your changes minimal and split them if you need to.
- Ensure there is a minimal reproduction attached for bug fixes.
- PR titles should follow conventional commit guidelines. Examples:
  - fix(scope): resolve xyz
  - feat: add a new feature
  - docs: improve wording

This will greatly help speed up the review process.

Thanks for your contribution ❤️

IMPORTANT IMPORTANT IMPORTANT IMPORTANT
-->
