### PR TITLE
fix(svg): escape color attributes in renderSVG to prevent SVG/XML injection

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -49,7 +49,7 @@ export function renderUnicodeCompact(
   data: QrCodeGenerateData,
   options: QrCodeGenerateOptions = {},
 ) {
-  const platte = {
+  const palette = {
     WHITE_ALL: '\u2588',
     WHITE_BLACK: '\u2580',
     BLACK_WHITE: '\u2584',
@@ -67,13 +67,13 @@ export function renderUnicodeCompact(
   for (let row = 0; row < result.size; row += 2) {
     for (let col = 0; col < result.size; col++) {
       if (at(col, row) === WHITE && at(col, row + 1) === WHITE)
-        line += platte.WHITE_ALL
+        line += palette.WHITE_ALL
       else if (at(col, row) === WHITE && at(col, row + 1) === BLACK)
-        line += platte.WHITE_BLACK
+        line += palette.WHITE_BLACK
       else if (at(col, row) === BLACK && at(col, row + 1) === WHITE)
-        line += platte.BLACK_WHITE
+        line += palette.BLACK_WHITE
       else
-        line += platte.BLACK_ALL
+        line += palette.BLACK_ALL
     }
     lines.push(line)
     line = ''

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -2,6 +2,20 @@ import { encode } from './encode'
 import type { QrCodeGenerateData, QrCodeGenerateSvgOptions } from './types'
 
 /**
+ * Escapes special characters in a string for use in XML attributes.
+ * This function replaces characters such as `&`, `"`, `<`, and `>` with their corresponding XML entities to ensure that the string can be safely included in an XML attribute without causing parsing issues.
+ * @param {string} value - The string to escape for use in an XML attribute.
+ * @returns {string} The escaped string, safe for use in XML attributes.
+ */
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
  * Renders a QR code as an SVG string.
  * The function converts the input data into a QR code and then generates an SVG representation using the specified colours and pixel sizes.
  * @param {QrCodeGenerateData} data - The data to encode into the QR code. See {@link QrCodeGenerateData}.
@@ -23,19 +37,19 @@ export function renderSVG(
 
   let svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">`
 
-  const pathes: string[] = []
+  const paths: string[] = []
 
   for (let row = 0; row < result.size; row++) {
     for (let col = 0; col < result.size; col++) {
       const x = col * pixelSize
       const y = row * pixelSize
       if (result.data[row][col])
-        pathes.push(`M${x},${y}h${pixelSize}v${pixelSize}h-${pixelSize}z`)
+        paths.push(`M${x},${y}h${pixelSize}v${pixelSize}h-${pixelSize}z`)
     }
   }
 
-  svg += `<rect fill="${whiteColor}" width="${width}" height="${height}"/>`
-  svg += `<path fill="${blackColor}" d="${pathes.join('')}"/>`
+  svg += `<rect fill="${escapeAttr(whiteColor)}" width="${width}" height="${height}"/>`
+  svg += `<path fill="${escapeAttr(blackColor)}" d="${paths.join('')}"/>`
 
   svg += '</svg>'
   return svg

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -134,6 +134,33 @@ describe('should', () => {
 
   it('render-svg', () => {
     const svg = renderSVG('qrcode')
+    expect(svg.startsWith('<svg')).toBe(true)
+    expect(svg.endsWith('</svg>')).toBe(true)
     expect(svg).toMatchFileSnapshot('./output/out1.svg')
+  })
+
+  it('render-svg-custom-colors', () => {
+    const svg = renderSVG('test', {
+      whiteColor: '#E4D156',
+      blackColor: '#333',
+    })
+
+    expect(svg).toContain('fill="#E4D156"')
+    expect(svg).toContain('fill="#333"')
+  })
+
+  it('render-svg-custom-pixel-size', () => {
+    const svg = renderSVG('test', { pixelSize: 5 })
+    expect(svg).toContain('h5v5h-5z')
+  })
+
+  it('render-svg-escapes-color-attrs', () => {
+    const svg = renderSVG('test', {
+      whiteColor: '"><script>alert(1)</script>',
+      blackColor: 'red',
+    })
+
+    expect(svg).not.toContain('<script>')
+    expect(svg).toContain('&quot;&gt;&lt;script&gt;')
   })
 })


### PR DESCRIPTION
# Description

resolves #9 

This PR improves the safety of the `renderSVG` output by escaping SVG attribute values before inserting them into the generated markup + fixes some typos and adds tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG rendering with proper attribute escaping to prevent invalid characters in color values.

* **Tests**
  * Added comprehensive test coverage for SVG rendering with custom colors, pixel size options, and attribute escaping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->